### PR TITLE
Add shortcut to editor plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # Advent of Code - Godot
-This repo hosts my solutions made in [Godot](https://godotengine.org/) for Advent of Code 2023.
+This repo hosts my solutions made in [Godot](https://godotengine.org/)
+for [Advent of Code 2023](https://adventofcode.com/2023/).

--- a/addons/aoc/dock.gd
+++ b/addons/aoc/dock.gd
@@ -21,6 +21,9 @@ func solve_second(input: String) -> String:
 """
 
 
+var _last_run_day := 0
+var _last_run_part := 0
+
 @onready var _main_vbox: VBoxContainer = $ScrollContainer/MarginContainer/MainVBox
 @onready var _margin_container: MarginContainer = %MarginContainer
 @onready var _btn_initialize: Button = %Initialize
@@ -81,6 +84,12 @@ func setup() -> void:
 	)
 
 
+func run_active_solver() -> void:
+	var day = int(_input_day.value)
+	var part = 1 if _last_run_day != day else _last_run_part
+	_run(day, part, _get_input(day))
+
+
 func _get_input(day: int) -> String:
 	if not _input_data.text.strip_edges().is_empty():
 		return _input_data.text
@@ -138,6 +147,10 @@ func _initialize(day: int, input_data: String) -> void:
 
 func _run(day: int, part: int, input: String) -> void:
 	var notes: Array[Dictionary] = []
+	
+	_last_run_day = day
+	_last_run_part = part
+	print('Running solver for day %s part %s' % [day, part])
 	
 	input = input.strip_edges()
 	if input.is_empty():

--- a/addons/aoc/plugin.gd
+++ b/addons/aoc/plugin.gd
@@ -2,6 +2,9 @@
 extends EditorPlugin
 
 
+const COMMAND_RUN_KEY := "advent_of_code/run"
+var command_run_event := InputEventKey.new()
+
 const DOCK_SCENE := preload("dock.tscn")
 const Dock := preload("dock.gd")
 var dock: Dock
@@ -12,8 +15,49 @@ func _enter_tree() -> void:
 	add_control_to_dock(EditorPlugin.DOCK_SLOT_RIGHT_UL, dock)
 	dock.setup()
 	dock.filesystem_changed.connect(EditorInterface.get_resource_filesystem().scan)
+	
+	command_run_event.keycode = KEY_ENTER
+	command_run_event.alt_pressed = true
+	
+	var palette := EditorInterface.get_command_palette()
+	palette.add_command(
+		"Run",
+		COMMAND_RUN_KEY,
+		dock.run_active_solver,
+		command_run_event.as_text()
+	)
 
 
 func _exit_tree() -> void:
 	remove_control_from_docks(dock)
 	dock.queue_free()
+	
+	var palette := EditorInterface.get_command_palette()
+	palette.remove_command(COMMAND_RUN_KEY)
+
+
+func _input(event: InputEvent) -> void:
+	if command_run_event.is_match(event) and event.pressed and _script_focussed():
+		get_tree().root.set_input_as_handled()
+		dock.run_active_solver()
+
+
+func _script_focussed() -> bool:
+	var focussed_node := get_tree().root.gui_get_focus_owner()
+	
+	# Early exit if the current node isn't a CodeEdit
+	if not focussed_node is CodeEdit:
+		return false
+	
+	# Get a list of all code editors (CodeEdit children of the script editor)
+	var script_editor := EditorInterface.get_script_editor()
+	var todo := script_editor.get_children()
+	var code_editors: Array[CodeEdit]
+	while not todo.is_empty():
+		var current := todo.pop_back()
+		todo += current.get_children()
+		if current is CodeEdit:
+			code_editors.push_back(current)
+	
+	# Check if the currently focussed node is one of the code editors
+	return focussed_node in code_editors

--- a/addons/aoc/plugin.gd
+++ b/addons/aoc/plugin.gd
@@ -11,7 +11,7 @@ func _enter_tree() -> void:
 	dock = DOCK_SCENE.instantiate()
 	add_control_to_dock(EditorPlugin.DOCK_SLOT_RIGHT_UL, dock)
 	dock.setup()
-	dock.filesystem_changed.connect(get_editor_interface().get_resource_filesystem().scan)
+	dock.filesystem_changed.connect(EditorInterface.get_resource_filesystem().scan)
 
 
 func _exit_tree() -> void:


### PR DESCRIPTION
I've added `Alt + Enter` as a keyboard shortcut to run the last run solver again. My upstream branch `addon-improvements` will only ever contain changes for the addon and no puzzle solvers to keep merging simple.

Feel free to ignore/close this PR if you don't need it.